### PR TITLE
Replace WebPack references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ the "scripts" element.
 ```
 
 ## Task Runner Explorer
-Open Task Runner Explorer by right-clicking the WebPack
-configuration file and select **Task Runner Explorer** from
-the context menu:
+Open Task Runner Explorer by right-clicking the `package.json`
+file and select **Task Runner Explorer** from the context menu:
 
 ![Open Task Runner Explorer](art/open-trx.png)
 

--- a/src/TaskRunner/TaskRunnerProvider.cs
+++ b/src/TaskRunner/TaskRunnerProvider.cs
@@ -21,7 +21,7 @@ namespace NpmTaskRunner
             _icon = new BitmapImage(new Uri(@"pack://application:,,,/NpmTaskRunner;component/Resources/npm.png"));
         }
 
-        private void InitializeWebPackRunnerOptions()
+        private void InitializeNpmTaskRunnerOptions()
         {
             _options = new List<ITaskRunnerOption>();
             _options.Add(new TaskRunnerOption("Verbose", PackageIds.cmdVerbose, PackageGuids.guidVSPackageCmdSet, false, "-d"));
@@ -33,7 +33,7 @@ namespace NpmTaskRunner
             {
                 if (_options == null)
                 {
-                    InitializeWebPackRunnerOptions();
+                    InitializeNpmTaskRunnerOptions();
                 }
 
                 return _options;


### PR DESCRIPTION
Replace WebPack references in the README file and in `TaskRunnerProvider.cs`.