### PR TITLE
Set color variable via npm CLI option

### DIFF
--- a/src/TaskRunner/TaskRunnerProvider.cs
+++ b/src/TaskRunner/TaskRunnerProvider.cs
@@ -74,7 +74,7 @@ namespace NpmTaskRunner
             {
                 TaskRunnerNode task = new TaskRunnerNode(script, true)
                 {
-                    Command = new TaskRunnerCommand(workingDirectory, "cmd.exe", "/c npm run " + script),
+                    Command = new TaskRunnerCommand(workingDirectory, "cmd.exe", $"/c npm run {script} --color=always"),
                     Description = $"Runs the '{script}' script",
                 };
 


### PR DESCRIPTION
This PR addresses issue https://github.com/madskristensen/NpmTaskRunner/issues/9 by enabling color via the npm `--color=always` CLI option. More info on the `color` option may be found [here](https://docs.npmjs.com/misc/config#color). Here's some sample output with this change in place:

![npm_task_runner_colors](https://cloud.githubusercontent.com/assets/10702007/12133813/9a4c740c-b3ee-11e5-9c76-b5e2a0f26548.png)


