### PR TITLE
Fix NullReferenceException in TaskParser.LoadTasks

### DIFF
--- a/src/TaskRunner/TaskParser.cs
+++ b/src/TaskRunner/TaskParser.cs
@@ -17,11 +17,15 @@ namespace NpmTaskRunner
                 string document = File.ReadAllText(configPath);
                 JObject root = JObject.Parse(document);
 
-                var children = root["scripts"].Children<JProperty>();
+                JToken scripts = root["scripts"];
 
-                foreach (var child in children)
-                {
-                    list.Add(child.Name);
+                if (scripts != null) {
+                    var children = scripts.Children<JProperty>();
+
+                    foreach (var child in children)
+                    {
+                        list.Add(child.Name);
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
When creating a new ASP.NET Core project via the project template, the generated `package.json` file doesn't define a `scripts` property. Because the `scripts` property isn't present, the code in `TaskParser.LoadTasks` fails with an object reference error:

![nullreferenceexception](https://cloud.githubusercontent.com/assets/10702007/13099800/c422b75e-d4fb-11e5-9350-fe7ba43f45ae.png)

The code was assuming that the `scripts` section is always present. This PR adds a null check before trying to access the property's children.