### PR TITLE
add support for yarn workspaces

### DIFF
--- a/src/TaskRunner/TaskRunnerProvider.cs
+++ b/src/TaskRunner/TaskRunnerProvider.cs
@@ -166,14 +166,19 @@ namespace NpmTaskRunner
         {
             var cwd = Path.GetDirectoryName(configPath);
 
-            var yarnCleanPath = Path.Combine(cwd, ".yarnclean");
-            var yarnConfigPath = Path.Combine(cwd, ".yarnrc");
-            var yarnLockPath = Path.Combine(cwd, "yarn.lock");
-
-            // if "yarn.lock", ".yarnrc", or ".yarnclean" file exists at same level as package.json, switch to Yarn CLI
-            if (File.Exists(yarnCleanPath) || File.Exists(yarnConfigPath) || File.Exists(yarnLockPath))
+            while (cwd != null)
             {
-                return Constants.YARN_CLI_COMMAND;
+                var yarnCleanPath = Path.Combine(cwd, ".yarnclean");
+                var yarnConfigPath = Path.Combine(cwd, ".yarnrc");
+                var yarnLockPath = Path.Combine(cwd, "yarn.lock");
+
+                // if "yarn.lock", ".yarnrc", or ".yarnclean" file exists at same level as package.json, switch to Yarn CLI
+                if (File.Exists(yarnCleanPath) || File.Exists(yarnConfigPath) || File.Exists(yarnLockPath))
+                {
+                    return Constants.YARN_CLI_COMMAND;
+                }
+
+                cwd = Path.GetDirectoryName(cwd);
             }
 
             return Constants.NPM_CLI_COMMAND;


### PR DESCRIPTION
This trivial commit add support for yarn workspaces. 

https://classic.yarnpkg.com/lang/en/docs/workspaces/

In yarn when workspaces are used, the yarn.lock file is created only for the package.json in a parent folder, not on each package.json of a module. This makes NPM Task runner think that we are using npm instead of yarn. 

This repo looks 'done' and I'm sure @madskristensen is super bussy... any change to get this merged/published soon? 

I could publish my own version but I would really like to avoid it if possible. 

Thanks for the great work! As C#+TypeScript developers we have been happy users of NPM Task runner for years.